### PR TITLE
Add installation instructions for ligolo-interface script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ configuration and remove an existing interface.
 - [jq](https://jqlang.github.io/jq/) for reading JSON files
 - Root privileges to manage network interfaces
 
+## Installation
+
+To make the script available system-wide, copy it to a directory that is in
+your `PATH`, such as `/usr/local/bin`:
+
+```bash
+sudo install -m 0755 ligolo-interface.sh /usr/local/bin/ligolo-interface
+```
+
+You can now run the script from anywhere with `ligolo-interface`.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to install the script in a PATH directory
- show the install command that copies the script to /usr/local/bin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb19a519dc832984b35827bbcc563a