### PR TITLE
Handle apt-get failures during jq auto install

### DIFF
--- a/ligolo-interface.sh
+++ b/ligolo-interface.sh
@@ -30,8 +30,18 @@ ensure_jq() {
   fi
 
   echo "🔄 Installation de 'jq' via apt-get..."
-  apt-get update
-  apt-get install -y jq
+
+  if ! apt-get update; then
+    echo "❌ Échec de 'apt-get update'. Impossible d'installer automatiquement 'jq'."
+    echo "ℹ️ Installez 'jq' manuellement puis relancez le script."
+    return 1
+  fi
+
+  if ! apt-get install -y jq; then
+    echo "❌ Échec de 'apt-get install'. Impossible d'installer automatiquement 'jq'."
+    echo "ℹ️ Installez 'jq' manuellement puis relancez le script."
+    return 1
+  fi
 
   if ! command -v jq >/dev/null 2>&1; then
     echo "❌ L'installation de 'jq' a échoué."


### PR DESCRIPTION
## Summary
- add error handling around apt-get update/install when auto-installing jq
- instruct the user to install jq manually if automatic installation fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccef20bc7883298adcb5dfe0148808